### PR TITLE
Release tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,3 +163,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 - [Clearlooks XFWM4](http://xfce-look.org/content/show.php/Clearlooks+for+XFWM4?content=137055) theme, under GPL.
 
 - Files in `wallpapers`, based on an [image from volvoguy](http://gnome-look.org/content/show.php?content=22210), under GPL.
+


### PR DESCRIPTION
Hello, could you please tag a release, so that jpfleury's version can be replaced with your fork at Debian ([requested here](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=961834#21)) and Arch ([discussed here](https://aur.archlinux.org/packages/clearlooks-phenix-gtk-theme#comment-867542))?

jpfleury's theme prints GTK deprecation warnings on stderr, and is locked out of the Debian stable releases, because of bugs.

As a side note, you may want to check out the [patches from Arch](https://aur.archlinux.org/packages/clearlooks-phenix-gtk-theme#pkgsrcslist).

Could you also enable issues on the repo, as a communication channel?

Thank you very much.